### PR TITLE
Feat(synthetics): Add new nodejs 9_1 runtime

### DIFF
--- a/packages/aws-cdk-lib/aws-synthetics/lib/runtime.ts
+++ b/packages/aws-cdk-lib/aws-synthetics/lib/runtime.ts
@@ -235,6 +235,19 @@ export class Runtime {
   public static readonly SYNTHETICS_NODEJS_PUPPETEER_9_0 = new Runtime('syn-nodejs-puppeteer-9.0', RuntimeFamily.NODEJS);
 
   /**
+   * `syn-nodejs-puppeteer-9.1` includes the following:
+   * - Lambda runtime Node.js 20.x
+   * - Puppeteer-core version 22.12.1
+   * - Chromium version 126.0.6478.126
+   *
+   * New Features:
+   * - **Bug fixes** Bug fix related to date ranges and pending requests in HAR files.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Library_nodejs_puppeteer.html#CloudWatch_Synthetics_runtimeversion-nodejs-puppeteer-9.1
+   */
+  public static readonly SYNTHETICS_NODEJS_PUPPETEER_9_1 = new Runtime('syn-nodejs-puppeteer-9.1', RuntimeFamily.NODEJS);
+
+  /**
    * `syn-python-selenium-1.0` includes the following:
    * - Lambda runtime Python 3.8
    * - Selenium version 3.141.0


### PR DESCRIPTION
### Issue # (if applicable)

No issue

### Reason for this change

There is a new runtime that was published. [syn-nodejs-puppeteer-9.1]/(https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Library_nodejs_puppeteer.html#CloudWatch_Synthetics_runtimeversion-nodejs-puppeteer-9.1)

### Description of changes

Just adding the new runtime.

### Description of how you validated changes

Against documentation and updating that the template deploys with the new runtime version.

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
